### PR TITLE
--show-errors added

### DIFF
--- a/autogradescoper/scripts/eval_r_func_args.py
+++ b/autogradescoper/scripts/eval_r_func_args.py
@@ -53,10 +53,12 @@ def eval_r_func_args(_args):
 
     # Calculate score and handle errors
     str_details = ""
+    str_errors = ""
     if usr_exit_code != 0:
        score = "error"
        # Print or log the error message
-       str_details = f"ERROR: The code returned an error, with exit code {usr_exit_code}.\nError message: {usr_error_message}"
+       str_details = f"ERROR: The code returned an error, with exit code {usr_exit_code}.\n"
+       str_errors = f"Error message: {usr_error_message}"
     
     
     
@@ -94,6 +96,11 @@ def eval_r_func_args(_args):
     ## write the detailed output to the output file
     with open(f"{args.out_prefix}.details", 'w') as fdetails:
         fdetails.write(str_details)
+        fdetails.write("\n")
+
+    ## write the detailed errors to the output file
+    with open(f"{args.out_prefix}.errors", 'w') as ferrors:
+        fdetails.write(str_errors)
         fdetails.write("\n")
 
 

--- a/autogradescoper/scripts/eval_r_func_args.py
+++ b/autogradescoper/scripts/eval_r_func_args.py
@@ -100,8 +100,8 @@ def eval_r_func_args(_args):
 
     ## write the detailed errors to the output file
     with open(f"{args.out_prefix}.errors", 'w') as ferrors:
-        fdetails.write(str_errors)
-        fdetails.write("\n")
+        ferrors.write(str_errors)
+        ferrors.write("\n")
 
 
 #    logger.info(f"Analysis finished with the final score: {score} and elapsed time: {usr_elapsed_time:.3f}s")

--- a/autogradescoper/scripts/eval_r_func_problem.py
+++ b/autogradescoper/scripts/eval_r_func_problem.py
@@ -85,6 +85,9 @@ def eval_r_func_problem(_args):
         if args.show_details:
             with open(f"{args.out_prefix}.{i}.details", 'r') as fdetails:
                 out_str += f"-----------------------------\n{fdetails.read()}"
+        if args.show_errors:
+            with open(f"{args.out_prefix}.{i}.errors", 'r') as ferrors:
+                out_str += f"-----------------------------\n{ferrors.read()}"
         out_strs.append(out_str)
     outdict["score"] = sum_scores
     outdict["elapsed"] = sum_elapsed

--- a/autogradescoper/scripts/eval_r_func_problem.py
+++ b/autogradescoper/scripts/eval_r_func_problem.py
@@ -22,6 +22,7 @@ def parse_arguments(_args):
     key_params.add_argument('--default-maxtime', type=int, default=10, help='Maximum time in seconds to run the R function')
     key_params.add_argument('--show-args', action='store_true', default=False, help='Show the arguments to user output')
     key_params.add_argument('--show-details', action='store_true', default=False, help='Show the correct and incorrect output to user output')
+    key_params.add_argument('--show-errors', action='store_true', default=False, help='Show the detailed errors to user output')
 
     if len(_args) == 0:
         parser.print_help()

--- a/autogradescoper/scripts/eval_r_func_probset.py
+++ b/autogradescoper/scripts/eval_r_func_probset.py
@@ -62,7 +62,7 @@ def eval_r_func_probset(_args):
                         (["--preload-sol", preload_sol] if preload_sol is not None else []) +
                         (["--log"] if args.log else []) +
                         (["--show-args"] if args.show_args else []) +
-                        (["--show-details"] if args.show_details else [])) +
+                        (["--show-details"] if args.show_details else []) +
                         (["--show-errors"] if args.show_errors else []))
         
         ## loading the json output

--- a/autogradescoper/scripts/eval_r_func_probset.py
+++ b/autogradescoper/scripts/eval_r_func_probset.py
@@ -17,6 +17,7 @@ def parse_arguments(_args):
     key_params.add_argument('--log', action='store_true', default=False, help='Write log to file')
     key_params.add_argument('--show-args', action='store_true', default=False, help='Show the arguments to user output')
     key_params.add_argument('--show-details', action='store_true', default=False, help='Show the correct and incorrect output to user output')
+    key_params.add_argument('--show-errors', action='store_true', default=False, help='Show the detailed errors to user output')
 
     if len(_args) == 0:
         parser.print_help()
@@ -61,7 +62,8 @@ def eval_r_func_probset(_args):
                         (["--preload-sol", preload_sol] if preload_sol is not None else []) +
                         (["--log"] if args.log else []) +
                         (["--show-args"] if args.show_args else []) +
-                        (["--show-details"] if args.show_details else []))
+                        (["--show-details"] if args.show_details else [])) +
+                        (["--show-errors"] if args.show_errors else []))
         
         ## loading the json output
         jsons.append(load_file_to_dict(f"{out_prefix}.json"))


### PR DESCRIPTION
Hi Prof. Hyun, I managed to show error messages with --show-errors option. Now we can edit the autograder to control whether students can see the detailed errors or not. This is what this pull request is about.

I would think about how we can customize different types of errors